### PR TITLE
handle snapshot completion entirely with awk

### DIFF
--- a/VBoxManage
+++ b/VBoxManage
@@ -271,11 +271,14 @@ _VBoxManage() {
         snap=$(VBoxManage snapshot "${name//\\/}" \
             list | \
             grep UUID |
-            awk -F ': ' '{print $2}' | \
-            sed 's/ (.*//' | \
-            tr '\n' '|' | \
-            sed 's/|$//' | \
-            sed 's/\s/\\ /g')
+            awk -F ': *' -v ORS='|' '/UUID: / {
+              n=$2; u=$3
+              sub(/..UUID/, "", n)
+              gsub(/ /, "\\ ", n);
+              sub(/[)].*/, "", u)
+              print n; print u
+              }'
+        )
         IFS='|' read -ra snap <<< "$snap"
 
         for item in "${snap[@]}"


### PR DESCRIPTION
fixes #5
Also list and complete snapshot uuid.

Here is the result :

    $ vbm snapshot debian delete <TAB>
    4044ac15-6025-4eba-9d7d-fe6ed1e82e04  first\ tryage
    64f93dfc-5331-41b6-968d-fa1157ff4ac6  second\ tryage
    $ vbm snapshot debian delete s<TAB>
    $ vbm snapshot debian delete second\ tryage
    Deleting snapshot 'second tryage' (4044ac15-6025-4eba-9d7d-fe6ed1e82e04)
    0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
    $ vbm snapshot debian delete <TAB>
    64f93dfc-5331-41b6-968d-fa1157ff4ac6  first\ tryage
    $ vbm snapshot debian delete 6<TAB>
    $ vbm snapshot debian delete 64f93dfc-5331-41b6-968d-fa1157ff4ac6
    Deleting snapshot 'first tryage' (64f93dfc-5331-41b6-968d-fa1157ff4ac6)
    0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
