### PR TITLE
change comp_words to upper case

### DIFF
--- a/VBoxManage
+++ b/VBoxManage
@@ -1029,8 +1029,8 @@ _VBoxManage() {
                             --ignore-operhaned-processes --profile
                             --dos2unix --unix2dos --username --domain --)
 
-                            [[ " ${comp_words[@]} " != *" --password "* ||
-                                " ${comp_words[@]} " != *" --passwordfile "* ]] &&
+                            [[ " ${COMP_WORDS[@]} " != *" --password "* ||
+                                " ${COMP_WORDS[@]} " != *" --passwordfile "* ]] &&
                                 items+=(--passwordfile --password)
                             [[ " ${COMP_WORDS[@]} " != *" --putenv "* &&
                                 " ${COMP_WORDS[@]} " != *" -E "* ]] &&
@@ -1057,8 +1057,8 @@ _VBoxManage() {
                             --ignore-operhaned-processes --profile
                             --username --domain --passwordfile --password --)
 
-                            [[ " ${comp_words[@]} " != *" --password "* ||
-                                " ${comp_words[@]} " != *" --passwordfile "* ]] &&
+                            [[ " ${COMP_WORDS[@]} " != *" --password "* ||
+                                " ${COMP_WORDS[@]} " != *" --passwordfile "* ]] &&
                                 items+=(--passwordfile --password)
                             [[ " ${COMP_WORDS[@]} " != *" --verbose "* &&
                                 " ${COMP_WORDS[@]} " != *" -v "* ]] &&
@@ -1078,8 +1078,8 @@ _VBoxManage() {
                             [[ " ${COMP_WORDS[@]} " != *" --recursive "* &&
                                 " ${COMP_WORDS[@]} " != *" -R "* ]] &&
                                 items+=(--recursive -R)
-                            [[ " ${comp_words[@]} " != *" --password "* ||
-                                " ${comp_words[@]} " != *" --passwordfile "* ]] &&
+                            [[ " ${COMP_WORDS[@]} " != *" --password "* ||
+                                " ${COMP_WORDS[@]} " != *" --passwordfile "* ]] &&
                                 items+=(--passwordfile --password)
                             [[ " ${COMP_WORDS[@]} " != *" --verbose "* &&
                                 " ${COMP_WORDS[@]} " != *" -v "* ]] &&


### PR DESCRIPTION
Hi,

There are a few `comp_words` in lower case. I think they should be upper case as man bash only mention upper case COMP_WORDS.