### PR TITLE
Use `grep -E` instead of `egrep` to suppress warnings

### DIFF
--- a/VBoxManage
+++ b/VBoxManage
@@ -164,8 +164,8 @@ _VBoxManage() {
         compopt -o filenames
 
         vms=$(VBoxManage list vms -l | \
-            egrep '^Name|State' | \
-            egrep -B1 'State:\s+saved' | \
+            grep -E '^Name|State' | \
+            grep -E -B1 'State:\s+saved' | \
             grep Name |$VBMC_SED 's/Name:\s\+//' | \
             tr '\n' '|' | \
             $VBMC_SED 's/|$//' | \
@@ -199,7 +199,7 @@ _VBoxManage() {
         local item
 
         list=$(VBoxManage list ostypes | \
-            egrep ^ID: | \
+            grep -E ^ID: | \
             $VBMC_SED 's/ID:\s\+//' | \
             tr '\n' '|' | \
             $VBMC_SED 's/|$//')
@@ -234,7 +234,7 @@ _VBoxManage() {
         local item
 
         list=$(VBoxManage list hostonlyifs | \
-            egrep ^Name: | \
+            grep -E ^Name: | \
             $VBMC_SED 's/Name:\s\+//' | \
             $VBMC_SED 's/\s/\\ /g'| \
             tr '\n' '|' | \
@@ -377,7 +377,7 @@ _VBoxManage() {
         local item
 
         list=$(VBoxManage list bridgedifs | \
-            egrep ^Name: | \
+            grep -E ^Name: | \
             $VBMC_SED 's/Name:\s\+//' | \
             $VBMC_SED 's/\s/\\ /g'| \
             tr '\n' '|' | \
@@ -395,7 +395,7 @@ _VBoxManage() {
         local item
 
         list=$(VBoxManage list intnets| \
-            egrep ^Name: | \
+            grep -E ^Name: | \
             $VBMC_SED 's/Name:\s\+//' | \
             $VBMC_SED 's/\s/\\ /g'| \
             tr '\n' '|' | \


### PR DESCRIPTION
The messages were getting in the way:
```
 $ VBoxManage createvm --name=Win10-3 --ostype Wegrep: warning: egrep is obsolescent; using grep -E
indowsegrep: warning: egrep is obsolescent; using grep -E
egrep: warning: egrep is obsolescent; using grep -E

Windows10        Windows2000      Windows2008      Windows2016_64   Windows31        Windows8         Windows8_64      WindowsMe        WindowsNT4       WindowsVista_64
Windows10_64     Windows2003      Windows2008_64   Windows2019_64   Windows7         Windows81        Windows95        WindowsNT        WindowsNT_64     WindowsXP
Windows11_64     Windows2003_64   Windows2012_64   Windows2022_64   Windows7_64      Windows81_64     Windows98        WindowsNT3x      WindowsVista     WindowsXP_64
matt@q ~ $ VBoxManage createvm --name=Win10-3 --ostype Windowsegrep: warning: egrep is obsolescent; using grep -E

Windows10        Windows2000      Windows2008      Windows2016_64   Windows31        Windows8         Windows8_64      WindowsMe        WindowsNT4       WindowsVista_64
Windows10_64     Windows2003      Windows2008_64   Windows2019_64   Windows7         Windows81        Windows95        WindowsNT        WindowsNT_64     WindowsXP
Windows11_64     Windows2003_64   Windows2012_64   Windows2022_64   Windows7_64      Windows81_64     Windows98        WindowsNT3x      WindowsVista     WindowsXP_64
```